### PR TITLE
fix polymorphic relationship w/ inherited classes

### DIFF
--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -20,7 +20,7 @@ class Dog < ActiveRecord::Base
 end
 
 class Glove < ActiveRecord::Base
-  belongs_to_polymorphic :gentleman, :as => :wearer
+  belongs_to_polymorphic :gentleman, :gentlewoman, :as => :wearer
   validates_polymorph :wearer
 end
 
@@ -30,18 +30,25 @@ end
 class Knight < Gentleman
 end
 
-describe Shoe do
+class Gentlewoman < Woman
+end
 
-  let(:shoe) { Shoe.new(attributes) }
+
+describe "polymorphic interface" do
+
   let(:man) { Man.create! }
   let(:woman) { Woman.create! }
+  let(:gentleman) { Gentleman.create! }
+  let(:knight) { Knight.create! }
 
   describe "class level constant" do
     specify { Shoe::WEARER_KEYS.should == ["man_id", "woman_id"] }
+    specify { Glove::WEARER_KEYS.should == ["gentleman_id", "gentlewoman_id"] }
   end
 
   describe "helper methods" do
     specify { Shoe.new.wearer_types.should == ["man", "woman"] }
+    specify { Glove.new.wearer_types.should == ["gentleman", "gentlewoman"] }
   end
 
   it "make the dynamically defined validation method private" do
@@ -49,7 +56,8 @@ describe Shoe do
       include?(:polymorphic_wearer_relationship_is_valid).should be_true
   end
 
-  describe "dynamic generated setter" do
+  describe "setter methods for ActiveRecord objects" do
+    let(:shoe) { Shoe.new(attributes) }
     let(:attributes) { {} }
 
     it "sets the correct attribute value for the setter" do
@@ -73,73 +81,90 @@ describe Shoe do
                         "Invalid type. Must be one of {man, woman}")
     end
 
-    it "does not throw an error if the assigned object is a subclass of a valid type" do
-      gentleman = Gentleman.create!
+    it "does not throw an error if the assigned object is a subclass of a
+    valid type" do
       expect { shoe.wearer = gentleman }.not_to raise_error
       shoe.man_id.should == gentleman.id
     end
 
-    it "does not throw an error if the assigned object is a descendant of a valid type" do
-      knight = Knight.create!
+    it "does not throw an error if the assigned object is a descendant of a
+    valid type" do
       expect { shoe.wearer = knight }.not_to raise_error
       shoe.man_id.should == knight.id
     end
+  end
 
-    it "does not throw an error if the association is to a parent class of
-    assigned object that is not the base" do
-      glove = Glove.new({})
-      knight = Knight.create!
-      expect { glove.wearer = knight }.not_to raise_error
-      glove.man_id.should == knight.id
+  describe "setter methods for objects inheriting from ActiveRecord objects" do
+    let(:glove) { Glove.new }
+
+    it "throws an error if the assigned object is an instance of the parent
+    ActiveRecord class" do
+      expect { glove.wearer = man }.to raise_error(
+        Polymorpheus::Interface::InvalidTypeError,
+        "Invalid type. Must be one of {gentleman, gentlewoman}"
+      )
     end
 
-    it "throws an error if assigned object is a less specific instance of the association" do
-      glove = Glove.new({})
-      man = Man.create!
-      expect { glove.wearer = man }
-        .to raise_error(Polymorpheus::Interface::InvalidTypeError,
-                        "Invalid type. Must be one of {gentleman}")
+    it "works if the assigned object is of the specified class" do
+      expect { glove.wearer = gentleman }.not_to raise_error
+      glove.gentleman_id.should == gentleman.id
+    end
+
+    it "works if the assigned object is an instance of a child class" do
+      expect { glove.wearer = knight }.not_to raise_error
+      glove.gentleman_id.should == knight.id
     end
   end
 
-  shared_examples_for "invalid polymorphic relationship" do
+  context "when there is no relationship defined" do
+    let(:shoe) { Shoe.new }
+
     specify { shoe.wearer.should == nil }
     specify { shoe.wearer_active_key.should == nil }
     specify { shoe.wearer_query_condition.should == nil }
-    it "validates appropriately" do
+
+    it "sets validation errors" do
+      shoe.valid?.should be_false
+      shoe.errors[:base].should ==
+        ["You must specify exactly one of the following: {man, woman}"]
+    end
+end
+
+  context "when there are multiple relationships defined" do
+    let(:shoe) { Shoe.new(man_id: man.id, woman_id: woman.id) }
+
+    specify { shoe.wearer.should == nil }
+    specify { shoe.wearer_active_key.should == nil }
+    specify { shoe.wearer_query_condition.should == nil }
+
+    it "sets validation errors" do
       shoe.valid?.should be_false
       shoe.errors[:base].should ==
         ["You must specify exactly one of the following: {man, woman}"]
     end
   end
 
-  context "when there is no relationship defined" do
-    let(:attributes) { {} }
-    it_should_behave_like "invalid polymorphic relationship"
-  end
-
-  context "when there are multiple relationships defined" do
-    let(:attributes) { { man_id: man.id, woman_id: woman.id } }
-    it_should_behave_like "invalid polymorphic relationship"
-  end
-
   context "when there is exactly one relationship defined" do
-    shared_examples_for "valid polymorphic relationship" do
+    context "and we have specified it via the id value" do
+      let(:shoe) { Shoe.new(man_id: man.id) }
+
       specify { shoe.wearer.should == man }
       specify { shoe.wearer_active_key.should == 'man_id' }
       specify { shoe.wearer_query_condition.should == { 'man_id' => man.id } }
     end
-    context "and we have specified it via the id value" do
-      let(:attributes) { { man_id: man.id } }
-      it_should_behave_like "valid polymorphic relationship"
+
+    context "and we have set the associated object directly" do
+      let(:shoe) { Shoe.new(man: man) }
+
+      specify { shoe.wearer.should == man }
+      specify { shoe.wearer_active_key.should == 'man_id' }
+      specify { shoe.wearer_query_condition.should == { 'man_id' => man.id } }
     end
-    context "and we have specified it via the id value" do
-      let(:attributes) { { man: man } }
-      it_should_behave_like "valid polymorphic relationship"
-    end
+
     context "and the record we are linking to is a new record" do
       let(:new_man) { Man.new }
-      let(:attributes) { { man: new_man } }
+      let(:shoe) { Shoe.new(man: new_man) }
+
       specify { shoe.wearer.should == new_man }
       specify { shoe.wearer_active_key.should be_nil }
       specify { shoe.wearer_query_condition.should be_nil }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define do
     t.integer :woman_id
   end
   create_table :gloves do |t|
-    t.integer :man_id
-    t.integer :woman_id
+    t.integer :gentleman_id
+    t.integer :gentlewoman_id
   end
   create_table :men do |t|
     t.string :type


### PR DESCRIPTION
When defining a polymorphic relationship with an object of a type that inherits
from an ActiveRecord class, rather than an instance of the AR class itself, the
id columns should be named according to the associated object, not the parent
ActiveRecord class.
