### PR TITLE
Avoid postgres exception

### DIFF
--- a/lib/polymorpheus.rb
+++ b/lib/polymorpheus.rb
@@ -26,5 +26,6 @@ module Polymorpheus
 end
 
 Polymorpheus::Adapter.register 'mysql2', 'polymorpheus/mysql_adapter'
+Polymorpheus::Adapter.register 'postgresql', 'polymorpheus/postgresql_adapter'
 
 require 'polymorpheus/railtie' if defined?(Rails)

--- a/lib/polymorpheus/postgresql_adapter.rb
+++ b/lib/polymorpheus/postgresql_adapter.rb
@@ -1,0 +1,6 @@
+module Polymorpheus
+  module ConnectionAdapters
+    module PostgresqlAdapter
+    end
+  end
+end

--- a/lib/polymorpheus/schema_dumper.rb
+++ b/lib/polymorpheus/schema_dumper.rb
@@ -9,11 +9,13 @@ module Polymorpheus
     def tables_with_triggers(stream)
       tables_without_triggers(stream)
 
-      @connection.triggers.collect(&:schema_statement).each do |statement|
-        stream.puts statement
+      if @connection.respond_to?(:triggers)
+        @connection.triggers.collect(&:schema_statement).each do |statement|
+          stream.puts statement
+        end
       end
+
       stream.puts
     end
   end
  end
-

--- a/lib/polymorpheus/version.rb
+++ b/lib/polymorpheus/version.rb
@@ -1,3 +1,3 @@
 module Polymorpheus
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
From the first commit:

Postgres is still not supported, but at the very least we should
make sure the gem doesn’t cause exceptions to be raised when used
alongside Postgres. This is relevant for a situation where we have
Polymorpheus in our Gemfile because our primary db is MySQL, but 
we are also using a secondary Postgres db.