### PR TITLE
add_polymorphic_constraints accept on_delete and on_update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ env:
   - AR=3.2.18
   - AR=4.0.5
   - AR=4.1.1
-  - AR=4.2.4
 before_script:
   - mysql -e 'create database polymorpheus_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ env:
   - AR=3.2.18
   - AR=4.0.5
   - AR=4.1.1
+  - AR=4.2.4
 before_script:
   - mysql -e 'create database polymorpheus_test;'

--- a/spec/mysql2_adapter_spec.rb
+++ b/spec/mysql2_adapter_spec.rb
@@ -99,6 +99,28 @@ describe Polymorpheus::ConnectionAdapters::MysqlAdapter do
       it_behaves_like "mysql2 migration statements"
     end
 
+    context "specifying an on update constraint" do
+      include_context "columns with short names"
+      let(:options) { { :on_update => :cascade } }
+      let(:fkey_sql) do
+        %{ ALTER TABLE `pets` ADD CONSTRAINT `pets_dog_id_fk` FOREIGN KEY (`dog_id`) REFERENCES `dogs`(id) ON UPDATE CASCADE
+           ALTER TABLE `pets` ADD CONSTRAINT `pets_kitty_id_fk` FOREIGN KEY (`kitty_id`) REFERENCES `cats`(name) ON UPDATE CASCADE }
+      end
+
+      it_behaves_like "mysql2 migration statements"
+    end
+
+    context "specifying on delete and on update constraints" do
+      include_context "columns with short names"
+      let(:options) { { :on_update => :cascade, :on_delete => :restrict } }
+      let(:fkey_sql) do
+        %{ ALTER TABLE `pets` ADD CONSTRAINT `pets_dog_id_fk` FOREIGN KEY (`dog_id`) REFERENCES `dogs`(id) ON DELETE RESTRICT ON UPDATE CASCADE
+           ALTER TABLE `pets` ADD CONSTRAINT `pets_kitty_id_fk` FOREIGN KEY (`kitty_id`) REFERENCES `cats`(name) ON DELETE RESTRICT ON UPDATE CASCADE }
+      end
+
+      it_behaves_like "mysql2 migration statements"
+    end
+
     context "when table and column names combined are very long" do
       include_context "columns with long names"
 


### PR DESCRIPTION
on_delete and on_update are accepted in the options parameter of add_polymorphic_constraints method, and passed to the `:option` option of foreigner gem. Accept the same arguments as [add_foreign_key](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key)

```
add_polymorphic_constraints 'pictures',
      { 'employee_id' => 'employees.id',
        'product_id' => 'products.id' },
      :on_delete => :cascade
```