### PR TITLE
Add options hash to belongs_to_polymorphic

### DIFF
--- a/lib/polymorpheus/interface/belongs_to_polymorphic.rb
+++ b/lib/polymorpheus/interface/belongs_to_polymorphic.rb
@@ -2,9 +2,10 @@ module Polymorpheus
   module Interface
     module BelongsToPolymorphic
       def belongs_to_polymorphic(*association_names, options)
-        polymorphic_api = options[:as]
+        polymorphic_api = options.delete(:as)
         builder = Polymorpheus::InterfaceBuilder.new(polymorphic_api,
-                                                     association_names)
+                                                     association_names,
+                                                     options)
 
         # The POLYMORPHEUS_ASSOCIATIONS constant is useful for two reasons:
         #
@@ -20,7 +21,7 @@ module Polymorpheus
 
         # Set belongs_to associations
         builder.associations.each do |association|
-          belongs_to association.name.to_sym
+          belongs_to association.name.to_sym, association.options
         end
 
         # Exposed interface for introspection

--- a/lib/polymorpheus/interface_builder.rb
+++ b/lib/polymorpheus/interface_builder.rb
@@ -6,10 +6,10 @@ module Polymorpheus
     attr_reader :interface_name,
                 :associations
 
-    def initialize(interface_name, association_names)
+    def initialize(interface_name, association_names, options)
       @interface_name = interface_name
       @associations = association_names.map do |association_name|
-        Polymorpheus::InterfaceBuilder::Association.new(association_name)
+        Polymorpheus::InterfaceBuilder::Association.new(association_name, options)
       end
     end
 

--- a/lib/polymorpheus/interface_builder/association.rb
+++ b/lib/polymorpheus/interface_builder/association.rb
@@ -5,10 +5,11 @@ module Polymorpheus
       include ActiveSupport::Inflector
 
       attr_reader :name,
-                  :key
+                  :key,
+                  :options
 
-      def initialize(name)
-        @name = name.to_s.downcase
+      def initialize(name, options)
+        @name, @options = name.to_s.downcase, options
         @key = "#{@name}_id"
       end
 

--- a/polymorpheus.gemspec
+++ b/polymorpheus.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 3.2', '< 4.2')
   s.add_development_dependency('rspec-rails', '~> 2.14.0')
   s.add_development_dependency('mysql2', '~> 0.3')
+  s.add_development_dependency('activerecord-tableless')
 end

--- a/polymorpheus.gemspec
+++ b/polymorpheus.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 3.2', '< 4.2')
   s.add_development_dependency('rspec-rails', '~> 2.14.0')
   s.add_development_dependency('mysql2', '~> 0.3')
-  s.add_development_dependency('activerecord-tableless')
 end

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -198,3 +198,18 @@ describe '.validates_polymorph' do
       ["You must specify exactly one of the following: {hero, villain}"]
   end
 end
+
+describe 'association options' do
+  it 'without options' do
+    Draw.new.association(:book).reflection.inverse_of.should == nil
+    Draw.new.association(:binder).reflection.inverse_of.should == nil
+    Book.new.association(:draws).reflection.inverse_of.should == nil
+    Binder.new.association(:draws).reflection.inverse_of.should == nil
+  end
+  it 'with options' do
+    Picture.new.association(:web_page).reflection.inverse_of.name.should == :pictures
+    Picture.new.association(:printed_work).reflection.inverse_of.name.should == :pictures
+    WebPage.new.association(:pictures).reflection.inverse_of.name.should == :web_page
+    PrintedWork.new.association(:pictures).reflection.inverse_of.name.should == :printed_work
+  end
+end

--- a/spec/support/class_defs.rb
+++ b/spec/support/class_defs.rb
@@ -1,3 +1,6 @@
+require 'activerecord-tableless'
+
+
 # this is normally done via a Railtie in non-testing situations
 ActiveRecord::Base.send :include, Polymorpheus::Interface
 
@@ -50,4 +53,28 @@ end
 # Trees, though, are masters of zen. They sway with the wind.
 # (Unless this is LOTR, but let's ignore that for now.)
 class Tree < ActiveRecord::Base
+end
+
+class TableLess < ActiveRecord::Base
+  has_no_table
+end
+
+class Draw < TableLess
+  belongs_to_polymorphic :book, :binder, as: :one_way_rel
+end
+class Book < TableLess
+  has_many_as_polymorph :draws
+end
+class Binder < TableLess
+  has_many_as_polymorph :draws
+end
+
+class Picture < TableLess
+  belongs_to_polymorphic :web_page, :printed_work, as: :inverted_rel, inverse_of: :pictures
+end
+class WebPage < TableLess
+  has_many_as_polymorph :pictures, inverse_of: :web_page
+end
+class PrintedWork < TableLess
+  has_many_as_polymorph :pictures, inverse_of: :printed_work
 end

--- a/spec/support/class_defs.rb
+++ b/spec/support/class_defs.rb
@@ -1,6 +1,3 @@
-require 'activerecord-tableless'
-
-
 # this is normally done via a Railtie in non-testing situations
 ActiveRecord::Base.send :include, Polymorpheus::Interface
 
@@ -55,26 +52,22 @@ end
 class Tree < ActiveRecord::Base
 end
 
-class TableLess < ActiveRecord::Base
-  has_no_table
-end
-
-class Draw < TableLess
+class Draw < ActiveRecord::Base
   belongs_to_polymorphic :book, :binder, as: :one_way_rel
 end
-class Book < TableLess
+class Book < ActiveRecord::Base
   has_many_as_polymorph :draws
 end
-class Binder < TableLess
+class Binder < ActiveRecord::Base
   has_many_as_polymorph :draws
 end
 
-class Picture < TableLess
+class Picture < ActiveRecord::Base
   belongs_to_polymorphic :web_page, :printed_work, as: :inverted_rel, inverse_of: :pictures
 end
-class WebPage < TableLess
+class WebPage < ActiveRecord::Base
   has_many_as_polymorph :pictures, inverse_of: :web_page
 end
-class PrintedWork < TableLess
+class PrintedWork < ActiveRecord::Base
   has_many_as_polymorph :pictures, inverse_of: :printed_work
 end

--- a/spec/support/db_setup.rb
+++ b/spec/support/db_setup.rb
@@ -15,6 +15,12 @@ ActiveRecord::Schema.define do
   create_table :alien_demigods
   create_table :supervillains
   create_table :trees
+  create_table :draws
+  create_table :books
+  create_table :binders
+  create_table :pictures
+  create_table :web_pages
+  create_table :printed_works
 
   create_table :story_arcs do |t|
     t.integer :hero_id


### PR DESCRIPTION
`has_many_as_polymorph` was accepting options, but `belongs_to_polymorphic` wasn't. Now we can write  

```
class Picture < ActiveRecord::Base
  belongs_to_polymorphic :web_page, :printed_work, as: :art_work, inverse_of: :pictures
end
```