### PR TITLE
Update CI build matrix to test latest ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.8
+  - 2.6.6
 gemfile:
   - gemfiles/3.0.gemfile
   - gemfiles/4.0.gemfile
@@ -48,6 +50,18 @@ matrix:
     - rvm: 2.4.1
       gemfile: gemfiles/4.0.gemfile
     - rvm: 2.4.1
+      gemfile: gemfiles/4.1.gemfile
+    - rvm: 2.5.8
+      gemfile: gemfiles/3.0.gemfile
+    - rvm: 2.5.8
+      gemfile: gemfiles/4.0.gemfile
+    - rvm: 2.5.8
+      gemfile: gemfiles/4.1.gemfile
+    - rvm: 2.6.6
+      gemfile: gemfiles/3.0.gemfile
+    - rvm: 2.6.6
+      gemfile: gemfiles/4.0.gemfile
+    - rvm: 2.6.6
       gemfile: gemfiles/4.1.gemfile
 before_script:
   - mysql -e 'create database polymorpheus_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 cache: bundler
+services:
+  - mysql
 rvm:
   - 1.9.3
   - 2.0.0

--- a/polymorpheus.gemspec
+++ b/polymorpheus.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 3.2', '<= 6.0')
 
   s.add_development_dependency('rake', '~> 10.4.2')
-  s.add_development_dependency('rspec', '~> 2.14.0')
+  s.add_development_dependency('rspec', '~> 3.9.0')
 end

--- a/spec/interface/belongs_to_polymorphic_spec.rb
+++ b/spec/interface/belongs_to_polymorphic_spec.rb
@@ -94,42 +94,52 @@ describe Polymorpheus::Interface::BelongsToPolymorphic do
     context 'when there is no relationship defined' do
       let(:story_arc) { StoryArc.new }
 
-      its(:associations) { should match_associations(:hero, :villain) }
-      its(:active_association) { should == nil }
-      its(:query_condition) { should == nil }
+      specify do
+        expect(interface.associations).to match_associations(:hero, :villain)
+      end
+      specify { expect(interface.active_association).to eq nil }
+      specify { expect(interface.query_condition).to eq nil }
     end
 
     context 'when there is are multiple relationships defined' do
       let(:story_arc) { StoryArc.new(hero_id: hero.id, villain_id: villain.id) }
 
-      its(:associations) { should match_associations(:hero, :villain) }
-      its(:active_association) { should == nil }
-      its(:query_condition) { should == nil }
+      specify do
+        expect(interface.associations).to match_associations(:hero, :villain)
+      end
+      specify { expect(interface.active_association).to eq nil }
+      specify { expect(interface.query_condition).to eq nil }
     end
 
     context 'when there is one relationship defined through the id value' do
       let(:story_arc) { StoryArc.new(hero_id: hero.id) }
 
-      its(:associations) { should match_associations(:hero, :villain) }
-      its(:active_association) { be_association(:hero) }
-      its(:query_condition) { should == { 'hero_id' => hero.id } }
+      specify do
+        expect(interface.associations).to match_associations(:hero, :villain)
+      end
+      specify { expect(interface.active_association).to be_association(:hero) }
+      specify { expect(interface.query_condition).to eq('hero_id' => hero.id) }
     end
 
     context 'when there is one relationship defined through the setter' do
       let(:story_arc) { StoryArc.new(character: hero) }
 
-      its(:associations) { should match_associations(:hero, :villain) }
-      its(:active_association) { be_association(:hero) }
-      its(:query_condition) { should == { 'hero_id' => hero.id } }
+      specify do
+        expect(interface.associations).to match_associations(:hero, :villain)
+      end
+      specify { expect(interface.active_association).to be_association(:hero) }
+      specify { expect(interface.query_condition).to eq('hero_id' => hero.id) }
     end
 
     context 'when there is one association, to a new record' do
       let(:new_hero) { Hero.new }
       let(:story_arc) { StoryArc.new(character: new_hero) }
 
-      its(:associations) { should match_associations(:hero, :villain) }
-      its(:active_association) { be_association(:hero) }
-      its(:query_condition) { should == nil }
+      specify do
+        expect(interface.associations).to match_associations(:hero, :villain)
+      end
+      specify { expect(interface.active_association).to be_association(:hero) }
+      specify { expect(interface.query_condition).to eq nil }
     end
   end
 end

--- a/spec/interface/belongs_to_polymorphic_spec.rb
+++ b/spec/interface/belongs_to_polymorphic_spec.rb
@@ -15,9 +15,12 @@ describe Polymorpheus::Interface::BelongsToPolymorphic do
     create_table :villains
   end
 
-  specify { StoryArc::POLYMORPHEUS_ASSOCIATIONS.should == %w[hero villain] }
-  specify { Superpower::POLYMORPHEUS_ASSOCIATIONS.should == %w[superhero
-                                                               supervillain] }
+  specify do
+    expect(StoryArc::POLYMORPHEUS_ASSOCIATIONS).to eq(%w[hero villain])
+  end
+  specify do
+    expect(Superpower::POLYMORPHEUS_ASSOCIATIONS).to eq(%w[superhero supervillain])
+  end
 
   describe "setter methods for ActiveRecord objects" do
     let(:story_arc) { StoryArc.new(attributes) }
@@ -25,37 +28,38 @@ describe Polymorpheus::Interface::BelongsToPolymorphic do
 
     it "sets the correct attribute value for the setter" do
       story_arc.character = hero
-      story_arc.hero_id.should == hero.id
-      story_arc.villain_id.should == nil
+      expect(story_arc.hero_id).to eq(hero.id)
+      expect(story_arc.villain_id).to eq(nil)
     end
 
     it "sets competing associations to nil" do
       story_arc.character = hero
-      story_arc.hero_id.should == hero.id
+      expect(story_arc.hero_id).to eq(hero.id)
       story_arc.character = villain
-      story_arc.villain_id.should == villain.id
-      story_arc.hero_id.should == nil
+      expect(story_arc.villain_id).to eq(villain.id)
+      expect(story_arc.hero_id).to eq(nil)
     end
 
     it "throws an error if the assigned object isn't a valid type" do
       create_table :trees
 
       tree = Tree.create!
-      expect { story_arc.character = tree }
-        .to raise_error(Polymorpheus::Interface::InvalidTypeError,
-                        "Invalid type. Must be one of {hero, villain}")
+      expect { story_arc.character = tree }.to raise_error(
+        Polymorpheus::Interface::InvalidTypeError,
+        "Invalid type. Must be one of {hero, villain}"
+      )
     end
 
     it "does not throw an error if the assigned object is a subclass of a
     valid type" do
       expect { story_arc.character = superhero }.not_to raise_error
-      story_arc.hero_id.should == superhero.id
+      expect(story_arc.hero_id).to eq(superhero.id)
     end
 
     it "does not throw an error if the assigned object is a descendant of a
     valid type" do
       expect { story_arc.character = alien_demigod }.not_to raise_error
-      story_arc.hero_id.should == alien_demigod.id
+      expect(story_arc.hero_id).to eq(alien_demigod.id)
     end
   end
 
@@ -79,12 +83,12 @@ describe Polymorpheus::Interface::BelongsToPolymorphic do
 
     it "works if the assigned object is of the specified class" do
       expect { superpower.wielder = superhero }.not_to raise_error
-      superpower.superhero_id.should == superhero.id
+      expect(superpower.superhero_id).to eq(superhero.id)
     end
 
     it "works if the assigned object is an instance of a child class" do
       expect { superpower.wielder = alien_demigod }.not_to raise_error
-      superpower.superhero_id.should == alien_demigod.id
+      expect(superpower.superhero_id).to eq(alien_demigod.id)
     end
   end
 

--- a/spec/interface/has_many_as_polymorph_spec.rb
+++ b/spec/interface/has_many_as_polymorph_spec.rb
@@ -16,54 +16,59 @@ describe Polymorpheus::Interface::HasManyAsPolymorph do
 
   it 'sets conditions on association to ensure we retrieve correct result' do
     hero = Hero.create!
-    hero.story_arcs.to_sql
-      .should match_sql(%{SELECT `story_arcs`.* FROM `story_arcs`
-                          WHERE `story_arcs`.`hero_id` = #{hero.id}
-                          AND `story_arcs`.`villain_id` IS NULL})
+    expect(hero.story_arcs.to_sql).to match_sql <<-EOS
+      SELECT `story_arcs`.* FROM `story_arcs`
+      WHERE `story_arcs`.`hero_id` = #{hero.id}
+      AND `story_arcs`.`villain_id` IS NULL
+    EOS
   end
 
   it 'supports existing conditions on the association' do
     villain = Villain.create!
-    villain.story_arcs.to_sql
-      .should match_sql(%{SELECT `story_arcs`.* FROM `story_arcs`
-                          WHERE `story_arcs`.`villain_id` = #{villain.id}
-                          AND `story_arcs`.`hero_id` IS NULL
-                          ORDER BY id DESC})
+    expect(villain.story_arcs.to_sql).to match_sql <<-EOS
+      SELECT `story_arcs`.* FROM `story_arcs`
+      WHERE `story_arcs`.`villain_id` = #{villain.id}
+      AND `story_arcs`.`hero_id` IS NULL
+      ORDER BY id DESC
+    EOS
   end
 
   it 'returns the correct result when used with new records' do
     villain = Villain.create!
     story_arc = StoryArc.create!(villain: villain, issue_id: 10)
-    Hero.new.story_arcs.where(issue_id: 10).should == []
+    expect(Hero.new.story_arcs.where(issue_id: 10)).to eq([])
   end
 
   it 'sets conditions on associations with enough specificity that they work
   in conjunction with has_many :through relationships' do
     hero = Hero.create!
-    hero.battles.to_sql
-      .should match_sql(%{SELECT `battles`.* FROM `battles`
-                          INNER JOIN `story_arcs`
-                          ON `battles`.`id` = `story_arcs`.`battle_id`
-                          WHERE `story_arcs`.`hero_id` = #{hero.id}
-                          AND `story_arcs`.`villain_id` IS NULL})
+    expect(hero.battles.to_sql).to match_sql <<-EOS
+      SELECT `battles`.* FROM `battles`
+      INNER JOIN `story_arcs`
+      ON `battles`.`id` = `story_arcs`.`battle_id`
+      WHERE `story_arcs`.`hero_id` = #{hero.id}
+      AND `story_arcs`.`villain_id` IS NULL
+    EOS
   end
 
   it 'uses the correct association table name when used in conjunction with a
   join condition' do
     battle = Battle.create!
-    battle.heros.to_sql
-      .should match_sql(%{SELECT `heros`.* FROM `heros`
-                          INNER JOIN `story_arcs`
-                          ON `heros`.`id` = `story_arcs`.`hero_id`
-                          WHERE `story_arcs`.`battle_id` = #{battle.id}})
+    expect(battle.heros.to_sql).to match_sql <<-EOS
+      SELECT `heros`.* FROM `heros`
+      INNER JOIN `story_arcs`
+      ON `heros`.`id` = `story_arcs`.`hero_id`
+      WHERE `story_arcs`.`battle_id` = #{battle.id}
+    EOS
 
-    battle.heros.joins(:story_arcs).to_sql
-      .should match_sql(%{SELECT `heros`.* FROM `heros`
-                          INNER JOIN `story_arcs` `story_arcs_heros`
-                          ON `story_arcs_heros`.`hero_id` = `heros`.`id`
-                          AND `story_arcs_heros`.`villain_id` IS NULL
-                          INNER JOIN `story_arcs`
-                          ON `heros`.`id` = `story_arcs`.`hero_id`
-                          WHERE `story_arcs`.`battle_id` = #{battle.id}})
+    expect(battle.heros.joins(:story_arcs).to_sql).to match_sql <<-EOS
+      SELECT `heros`.* FROM `heros`
+      INNER JOIN `story_arcs` `story_arcs_heros`
+      ON `story_arcs_heros`.`hero_id` = `heros`.`id`
+      AND `story_arcs_heros`.`villain_id` IS NULL
+      INNER JOIN `story_arcs`
+      ON `heros`.`id` = `story_arcs`.`hero_id`
+      WHERE `story_arcs`.`battle_id` = #{battle.id}
+    EOS
   end
 end

--- a/spec/interface/validates_polymorph_spec.rb
+++ b/spec/interface/validates_polymorph_spec.rb
@@ -13,23 +13,25 @@ describe Polymorpheus::Interface::ValidatesPolymorph do
     create_table(:villains)
   end
 
-  specify { StoryArc.new(character: hero).valid?.should == true }
-  specify { StoryArc.new(character: villain).valid?.should == true }
-  specify { StoryArc.new(hero_id: hero.id).valid?.should == true }
-  specify { StoryArc.new(hero: hero).valid?.should == true }
-  specify { StoryArc.new(hero: Hero.new).valid?.should == true }
+  specify { expect(StoryArc.new(character: hero).valid?).to eq(true) }
+  specify { expect(StoryArc.new(character: villain).valid?).to eq(true) }
+  specify { expect(StoryArc.new(hero_id: hero.id).valid?).to eq(true) }
+  specify { expect(StoryArc.new(hero: hero).valid?).to eq(true) }
+  specify { expect(StoryArc.new(hero: Hero.new).valid?).to eq(true) }
 
   it 'is invalid if no association is specified' do
     story_arc = StoryArc.new
-    story_arc.valid?.should == false
-    story_arc.errors[:base].should ==
+    expect(story_arc.valid?).to eq(false)
+    expect(story_arc.errors[:base]).to eq(
       ["You must specify exactly one of the following: {hero, villain}"]
+    )
   end
 
   it 'is invalid if multiple associations are specified' do
     story_arc = StoryArc.new(hero_id: hero.id, villain_id: villain.id)
-    story_arc.valid?.should == false
-    story_arc.errors[:base].should ==
+    expect(story_arc.valid?).to eq(false)
+    expect(story_arc.errors[:base]).to eq(
       ["You must specify exactly one of the following: {hero, villain}"]
+    )
   end
 end

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -7,10 +7,10 @@ describe Polymorpheus::Interface do
       create_table :books
       create_table :binders
 
-      Drawing.new.association(:book).reflection.inverse_of.should == nil
-      Drawing.new.association(:binder).reflection.inverse_of.should == nil
-      Book.new.association(:drawings).reflection.inverse_of.should == nil
-      Binder.new.association(:drawings).reflection.inverse_of.should == nil
+      expect(Drawing.new.association(:book).reflection.inverse_of).to eq(nil)
+      expect(Drawing.new.association(:binder).reflection.inverse_of).to eq(nil)
+      expect(Book.new.association(:drawings).reflection.inverse_of).to eq(nil)
+      expect(Binder.new.association(:drawings).reflection.inverse_of).to eq(nil)
     end
 
     it 'with options' do
@@ -18,10 +18,10 @@ describe Polymorpheus::Interface do
       create_table :web_pages
       create_table :printed_works
 
-      Picture.new.association(:web_page).reflection.inverse_of.name.should == :pictures
-      Picture.new.association(:printed_work).reflection.inverse_of.name.should == :pictures
-      WebPage.new.association(:pictures).reflection.inverse_of.name.should == :web_page
-      PrintedWork.new.association(:pictures).reflection.inverse_of.name.should == :printed_work
+      expect(Picture.new.association(:web_page).reflection.inverse_of.name).to eq(:pictures)
+      expect(Picture.new.association(:printed_work).reflection.inverse_of.name).to eq(:pictures)
+      expect(WebPage.new.association(:pictures).reflection.inverse_of.name).to eq(:web_page)
+      expect(PrintedWork.new.association(:pictures).reflection.inverse_of.name).to eq(:printed_work)
     end
   end
 end

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -30,10 +30,10 @@ describe Polymorpheus::SchemaDumper do
   end
 
   specify "the schema statement is part of the dump" do
-    subject.index(schema_statement).should be_a(Integer)
+    expect(subject.index(schema_statement)).to be_a(Integer)
   end
 
   specify "there is exactly one instance of the schema statement" do
-    subject.index(schema_statement).should == subject.rindex(schema_statement)
+    expect(subject.index(schema_statement)).to eq(subject.rindex(schema_statement))
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,31 +1,31 @@
 RSpec::Matchers.define :be_association do |association_name|
   match do |actual|
-    actual.should be_instance_of(Polymorpheus::InterfaceBuilder::Association)
-    actual.name.should == association_name.to_s
+    expect(actual).to be_instance_of Polymorpheus::InterfaceBuilder::Association
+    expect(actual.name).to eq association_name.to_s
   end
 end
 
 RSpec::Matchers.define :match_associations do |*association_names|
   match do |actual|
-    actual.length.should == association_names.length
+    expect(actual.length).to eq association_names.length
     actual.each_with_index do |item, ind|
-      item.should be_association(association_names[ind])
+      expect(item).to be_association(association_names[ind])
     end
   end
 end
 
 RSpec::Matchers.define :match_sql do |expected|
   match do |actual|
-    format(expected).should == format(actual)
+    expect(format(expected)).to eq format(actual)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected the following SQL statements to match:
     #{format(actual)}
     #{format(expected)}"
   end
 
   def format(sql)
-    sql.gsub(/\s+/, ' ')
+    sql.squish
   end
 end

--- a/spec/support/sql_test_helpers.rb
+++ b/spec/support/sql_test_helpers.rb
@@ -35,7 +35,7 @@ module SqlTestHelpers
     end
 
     def should_execute_sql(expected)
-      expect(clean_sql(sql.join("\n"))).to include(clean_sql(expected.squish))
+      expect(clean_sql(sql.join("\n"))).to include(clean_sql(expected))
     end
   end
 end

--- a/spec/trigger_spec.rb
+++ b/spec/trigger_spec.rb
@@ -19,27 +19,39 @@ describe Polymorpheus::Trigger do
   let(:collation_connection) { "utf8_general_ci" }
   let(:db_collation) { "utf8_unicode_ci" }
 
-  subject do
-    described_class.new([name, event, table, statement, timing, created,
-                         sql_mode, definer, charset, collation_connection,
-                         db_collation])
+  let(:trigger) do
+    described_class.new(
+      [
+        name,
+        event,
+        table,
+        statement,
+        timing,
+        created,
+        sql_mode,
+        definer,
+        charset,
+        collation_connection,
+        db_collation
+      ]
+    )
   end
 
-  its(:name) { should == name }
-  its(:event) { should == event }
-  its(:table) { should == table }
-  its(:statement) { should == statement }
-  its(:timing) { should == timing }
-  its(:created) { should == created }
-  its(:sql_mode) { should == sql_mode }
-  its(:definer) { should == definer }
-  its(:charset) { should == charset }
-  its(:collation_connection) { should == collation_connection }
-  its(:db_collation) { should == db_collation }
+  specify { expect(trigger.name).to eq name }
+  specify { expect(trigger.event).to eq event }
+  specify { expect(trigger.table).to eq table }
+  specify { expect(trigger.statement).to eq statement }
+  specify { expect(trigger.timing).to eq timing }
+  specify { expect(trigger.created).to eq created }
+  specify { expect(trigger.sql_mode).to eq sql_mode }
+  specify { expect(trigger.definer).to eq definer }
+  specify { expect(trigger.charset).to eq charset }
+  specify { expect(trigger.collation_connection).to eq collation_connection }
+  specify { expect(trigger.db_collation).to eq db_collation }
 
-  its(:columns) { should == %w{dog_id kitty_id} }
+  specify { expect(trigger.columns).to eq %w[dog_id kitty_id] }
 
-  its(:schema_statement) do
-    should == %{  add_polymorphic_triggers(:pets, ["dog_id", "kitty_id"])}
+  specify do
+    expect(trigger.schema_statement).to eq %{  add_polymorphic_triggers(:pets, ["dog_id", "kitty_id"])}
   end
 end


### PR DESCRIPTION
This PR adds ruby 2.5 and 2.6 to the Travis CI build matrix. 

In order to get builds running again, the `.travis.yml` config also needed to be updated to enable the mysql service.

Ruby 2.7 will be added in the future when a Rails 6 gemfile is added.